### PR TITLE
Add a rules/jokes ruleset

### DIFF
--- a/hydiomatic/rules.hy
+++ b/hydiomatic/rules.hy
@@ -1,5 +1,5 @@
 ;; hydiomatic -- The Hy Transformer
-;; Copyright (C) 2014, 2015  Gergely Nagy <algernon@madhouse-project.org>
+;; Copyright (C) 2014, 2015, 2016  Gergely Nagy <algernon@madhouse-project.org>
 ;;
 ;; This library is free software: you can redistribute it and/or
 ;; modify it under the terms of the GNU Lesser General Public License
@@ -23,6 +23,7 @@
         [hydiomatic.rulesets.optimo [*]]
         [hydiomatic.rulesets.warningso [*]]
         [hydiomatic.rulesets.grand-cleanupo [*]]
+        [hydiomatic.rulesets.jokeo [*]]
         [adderall.dsl [*]])
 (require adderall.dsl)
 (require hydiomatic.macros)
@@ -45,3 +46,6 @@
 
 (def rules/warnings
   [rules/warningsᵒ])
+
+(def rules/jokes
+  [rules/joke/canadaᵒ])

--- a/hydiomatic/rulesets/jokeo.hy
+++ b/hydiomatic/rulesets/jokeo.hy
@@ -1,0 +1,30 @@
+;; hydiomatic -- The Hy Transformer
+;; Copyright (C) 2014, 2015, 2016  Gergely Nagy <algernon@madhouse-project.org>
+;;
+;; This library is free software: you can redistribute it and/or
+;; modify it under the terms of the GNU Lesser General Public License
+;; as published by the Free Software Foundation, either version 3 of
+;; the License, or (at your option) any later version.
+;;
+;; This library is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+;; Lesser General Public License for more details.
+;;
+;; You should have received a copy of the GNU Lesser General Public
+;; License along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+(import [adderall.dsl [*]]
+        [adderall.extra.misc [*]]
+        [hy [HySymbol]])
+(require adderall.dsl)
+(require hydiomatic.macros)
+
+(defrules [rules/joke/canadaᵒ rules/joke/canadao]
+  ;; foo? => foo, eh?
+  (prep
+   (typeᵒ expr HySymbol)
+   (project [expr]
+            (if (.startswith expr "is_")
+              (≡ out (HySymbol (+ (cut expr 3) ", eh?")))
+              (≡ out expr)))))

--- a/tests/hydiomatic_tests.hy
+++ b/tests/hydiomatic_tests.hy
@@ -1,5 +1,5 @@
 ;; hydiomatic -- The Hy Transformer
-;; Copyright (C) 2014, 2015  Gergely Nagy <algernon@madhouse-project.org>
+;; Copyright (C) 2014, 2015, 2016  Gergely Nagy <algernon@madhouse-project.org>
 ;;
 ;; This library is free software: you can redistribute it and/or
 ;; modify it under the terms of the GNU Lesser General Public License
@@ -447,3 +447,10 @@
 
   (assert-cleanup (filterfalse odd? [1 2 3 4 5 6 7])
                   (remove odd? [1 2 3 4 5 6 7])))
+
+(defmacro assert-joke [expr expected]
+  `(assert (= (simplify '~expr rules/jokes)
+              ~expected)))
+
+(defn test-jokes []
+  (assert-joke foo? (HySymbol "foo, eh?")))


### PR DESCRIPTION
Inspired by a [tweet][1], this adds a -j option and a rules/jokes set, that currently transforms boolean symbol names to a Canadian accent.

 [1]: https://twitter.com/_jayphelps/status/704158893849448449

Thus, the symbol `foo?` becomes `foo, eh?`.